### PR TITLE
Rename 'tools' library to 'klab'

### DIFF
--- a/input/preparation/README.rst
+++ b/input/preparation/README.rst
@@ -19,5 +19,5 @@ backbone atoms (N, CA, and C only) back into the pruned, preminimized Rosetta st
 conformation (almost linearly and equidistantly spacing backbone atoms). This code can also
 be found in this script and could be adapted for other pruned input.
 
-This script relies on the Kortemme Lab tools repository which will be made at https://github.com/Kortemme-Lab/tools.
+This script relies on the Kortemme Lab tools repository which will be made at https://github.com/Kortemme-Lab/klab.
 

--- a/input/preparation/remove_native_information.py
+++ b/input/preparation/remove_native_information.py
@@ -42,7 +42,7 @@ Setup:
 The tools repository will be added as a Git submodule but can be set up as below. All commands should be run in the
 directory containing this script:
 
-i) git clone https://github.com/Kortemme-Lab/tools.git
+i) git clone https://github.com/Kortemme-Lab/klab.git
 or
 ii) (For Linux, Mac OS X, Cygwin): Clone the repository elsewhere and:
     ln -s /path/to/tools tools
@@ -73,21 +73,21 @@ import traceback
 if __name__ == '__main__':
     sys.path.insert(0, os.path.join('..', '..'))
 
-from tools import colortext
-import tools.bio.rcsb
-from tools.bio.basics import Residue, PDBResidue, Sequence, SequenceMap, residue_type_3to1_map, protonated_residue_type_3to1_map, non_canonical_amino_acids, protonated_residues_types_3, residue_types_3, Mutation, ChainMutation, SimpleMutation
-from tools.bio.basics import dna_nucleotides, rna_nucleotides, dna_nucleotides_3to1_map, dna_nucleotides_2to1_map, non_canonical_dna, non_canonical_rna, all_recognized_dna, all_recognized_rna
-from tools.bio.bonsai import Bonsai, PDBSection
-from tools.bio.fasta import FASTA
-from tools.bio.pdb import PDB
-from tools.bio.spackle import Spackler
-from tools.rosetta.map_pdb_residues import get_pdb_contents_to_pose_residue_map
-from tools.fs.fsio import read_file, write_file
-from tools.pymath.stats import get_mean_and_standard_deviation
-from tools.pymath.cartesian import spatialhash
-from tools.rosetta.map_pdb_residues import get_pdb_contents_to_pose_residue_map
-from tools.general.strutil import remove_trailing_line_whitespace as normalize_pdb_file
-from tools.rosetta.input_files import LoopsFile
+from klab import colortext
+import klab.bio.rcsb
+from klab.bio.basics import Residue, PDBResidue, Sequence, SequenceMap, residue_type_3to1_map, protonated_residue_type_3to1_map, non_canonical_amino_acids, protonated_residues_types_3, residue_types_3, Mutation, ChainMutation, SimpleMutation
+from klab.bio.basics import dna_nucleotides, rna_nucleotides, dna_nucleotides_3to1_map, dna_nucleotides_2to1_map, non_canonical_dna, non_canonical_rna, all_recognized_dna, all_recognized_rna
+from klab.bio.bonsai import Bonsai, PDBSection
+from klab.bio.fasta import FASTA
+from klab.bio.pdb import PDB
+from klab.bio.spackle import Spackler
+from klab.rosetta.map_pdb_residues import get_pdb_contents_to_pose_residue_map
+from klab.fs.fsio import read_file, write_file
+from klab.pymath.stats import get_mean_and_standard_deviation
+from klab.pymath.cartesian import spatialhash
+from klab.rosetta.map_pdb_residues import get_pdb_contents_to_pose_residue_map
+from klab.general.strutil import remove_trailing_line_whitespace as normalize_pdb_file
+from klab.rosetta.input_files import LoopsFile
 
 
 def prepare_structures(file_filter, output_directory, loop_definitions, require_filter = True, create_partial_structures = False, expected_min_loop_length = None, expected_max_loop_length = None, remove_hetatm = False):


### PR DESCRIPTION
Hey, I fixed this renamed library in our own copy of the repo, but thought it would be good to change in the original one...
Yuval